### PR TITLE
Improve packaging and testing for Starbucks POS example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Logs
+*.log
+
+# Environments
+.venv/
+venv/
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The program allows users to explore and combine ingredients to create drinks. Te
 ### 1. Setup the Environment
 Install the required dependencies:
 ```bash
-pip install rapidfuzz tabulate wcwidth
+pip install colorama rapidfuzz tabulate wcwidth
 ```
 Alternatively, install from `requirements.txt`:
 ```bash
@@ -64,9 +64,9 @@ You can easily modify the ingredient data:
 3. Save the file and relaunch the program.
 
 ## Testing
-Run tests using `test_project.py` to validate the core functions:
+Run tests using `pytest` to validate the core functions:
 ```bash
-pytest -s test_project.py
+pytest
 ```
 Focus on edge cases, such as misspelled inputs and invalid JSON structures.
 
@@ -80,6 +80,7 @@ Focus on edge cases, such as misspelled inputs and invalid JSON structures.
 3. Submit a pull request with a detailed description.
 
 ## Dependencies
+- `colorama`: For cross-platform terminal colors.
 - `rapidfuzz`: For fast string matching.
 - `tabulate`: For displaying data in table formats.
 - `wcwidth`: For managing string widths, including emojis.

--- a/data_utils.py
+++ b/data_utils.py
@@ -3,10 +3,23 @@ This module contains functions that are used to load, save and process data.
 """
 import re
 import json
-from colorama import Fore, Style, init
-from rapidfuzz import fuzz, process # type: ignore
-from tabulate import tabulate # type: ignore
-init()
+from rapidfuzz import fuzz, process  # type: ignore
+from tabulate import tabulate  # type: ignore
+
+try:
+    from colorama import Fore, Style, init
+except ModuleNotFoundError:  # pragma: no cover - fallback when colorama is missing
+    class Fore:  # type: ignore
+        GREEN = ""
+
+    class Style:  # type: ignore
+        RESET_ALL = ""
+
+    def init() -> None:  # type: ignore
+        """Compatibility stub when colorama is unavailable."""
+        return None
+else:
+    init()
 
 
 def load_data(file_path):

--- a/main_functions.py
+++ b/main_functions.py
@@ -3,9 +3,18 @@ This module contains the main functions of the program.
 """
 import sys
 from random import choice, randint
-from colorama import Style, init
 from data_utils import load_data, ai_input, display_data
-init()
+
+try:
+    from colorama import Style, init
+except ModuleNotFoundError:  # pragma: no cover - fallback when colorama is missing
+    class Style:  # type: ignore
+        RESET_ALL = ""
+
+    def init() -> None:  # type: ignore
+        return None
+else:
+    init()
 
 def start(file_path):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+colorama
 rapidfuzz
 tabulate
 wcwidth

--- a/test_project.py
+++ b/test_project.py
@@ -1,22 +1,31 @@
-"""
-This file contains the test functions for the functions in the main_functions.py file
-"""
+"""Test suite for Starbucks POS helper functions."""
+
 from data_utils import load_data
 from main_functions import iterate_data
 
-data = load_data("starbucks_data.json")
-ingredient_names = list(data.keys())
 
 def test_load_data():
-    """
-    Test the load_data function
-    """
-    assert load_data("starbucks_data.json") == data
-    assert load_data("starbucks_data.json") != {}
+    """Ensure JSON data is loaded into a dictionary with expected keys."""
+    data = load_data("starbucks_data.json")
+    assert isinstance(data, dict)
+    assert "Coffee And Espresso" in data
 
 
-def iterate_data_test():
-    """
-    Test the iterate_data function
-    """
-    assert iterate_data(["Coffee And Espresso", "Espresso Roast", ["chocolate", "vanilla", "hazelnut"]], data) == "milk, coffee, sugar"
+def test_iterate_data(monkeypatch):
+    """`iterate_data` should include the chosen addition in the output message."""
+    data = load_data("starbucks_data.json")
+    user_choice = [
+        "Coffee And Espresso",
+        "Espresso Roast",
+        ["chocolate", "vanilla", "hazelnut"],
+    ]
+
+    # Simulate user selecting "chocolate" and confirming the suggestion
+    inputs = iter(["chocolate", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    message = iterate_data(user_choice, data)
+    assert "Espresso Roast" in message
+    assert "chocolate" in message
+    assert "Additions" in message
+


### PR DESCRIPTION
## Summary
- add a `.gitignore` for Python caches and virtual environments
- document and require the missing `colorama` dependency
- provide optional fallbacks when `colorama` is unavailable
- rewrite the pytest suite with input simulation